### PR TITLE
allow https pull

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "bootcamp_generator/exercise_manager"]
 	path = bootcamp_generator/exercise_manager
-	url = git@gitlab.com:coursegit/exercise_manager.git
+	url = https://gitlab.com/coursegit/exercise_manager.git


### PR DESCRIPTION
ssh submodule pull will fail if user does not have ssh key added to gitlab, this will change to https pull. 